### PR TITLE
Remove Mongo::Collection#parallel_scan delegator

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -38,9 +38,6 @@ module Mongo
     # Delegate to the cluster for the next primary.
     def_delegators :cluster, :next_primary
 
-    # Convenience delegators to find.
-    def_delegators :find, :parallel_scan
-
     # Check if a collection is equal to another object. Will check the name and
     # the database for equality.
     #


### PR DESCRIPTION
Support for `parallelCollectionScan` was removed in c87ebef262657885ec6dd5cea18550dd8d8a7249.
